### PR TITLE
Fix problem with more than 100 elements in one routable type.

### DIFF
--- a/src/Routing/ContentfulSlugMatcher.php
+++ b/src/Routing/ContentfulSlugMatcher.php
@@ -256,6 +256,7 @@ class ContentfulSlugMatcher implements RequestMatcherInterface, UrlGeneratorInte
             try {
                 $entries = $this->client->getEntries(function (Query $query) use ($routableType) {
                     $query->setContentType($routableType);
+                    $query->setLimit(1000);
                 });
 
                 array_walk($entries, function ($entry) {


### PR DESCRIPTION
This is only a fast workaround.

See #9 