### PR TITLE
Remove string type from markdown extension, because unfilled values i…

### DIFF
--- a/src/Tests/Twig/MarkdownExtensionTest.php
+++ b/src/Tests/Twig/MarkdownExtensionTest.php
@@ -57,4 +57,12 @@ class MarkdownExtensionTest extends TestCase
     {
         static::assertSame('<h1>Headline</h1>', $this->fixture->parseMarkdown('#Headline'));
     }
+
+    /**
+     * Sometimes contentful sends empty fields as null, so we need a test for that
+     */
+    public function testParseMarkdownWithNull()
+    {
+        static::assertSame('', $this->fixture->parseMarkdown(null));
+    }
 }

--- a/src/Twig/MarkdownExtension.php
+++ b/src/Twig/MarkdownExtension.php
@@ -71,10 +71,10 @@ class MarkdownExtension extends Twig_Extension
 
     /**
      * Returns the rendered html.
-     * @param string $content
+     * @param mixed $content
      * @return string
      */
-    public function parseMarkdown(string $content): string
+    public function parseMarkdown($content): string
     {
         return $content ? $this->getParser()->toHtml($content) : '';
     }


### PR DESCRIPTION
…n contentful can be null